### PR TITLE
Update: Package total

### DIFF
--- a/README.template.md
+++ b/README.template.md
@@ -6,7 +6,7 @@
 
 Flutter Candies (糖果群) 成立于 2019 年 2 月 14 日，聚集了一群热爱 Flutter 的开发者们，糖果群致力于通过持续创建、维护和贡献高质量的 Flutter 插件和库 (Flutter / Dart Packages)，让 Flutter 更易用，助力开发者们更快、更高效地构建优秀的 Flutter 应用。
 
-我们已经在 pub.dev 上开源了超过 [50 个](https://pub-web.flutter-io.cn/publishers/fluttercandies.com/packages) 实用的 packages，不仅如此，我们还构建了很多实用工具、API、实战项目以及优质的技术文章，帮助 Flutter 开发者们在职业生涯的不同阶段快速成长。
+我们已经在 pub.dev 上开源了 [<!-- md:PubDashboard-total start -->0<!-- md:PubDashboard-total end --> 个](https://pub-web.flutter-io.cn/publishers/fluttercandies.com/packages) 实用的 packages，不仅如此，我们还构建了很多实用工具、API、实战项目以及优质的技术文章，帮助 Flutter 开发者们在职业生涯的不同阶段快速成长。
 
 我们希望号召和帮助更多开发者们为 Flutter 开发者更多实用的插件库 (小糖果)，如果你有同样的目标和理想，糖果群欢迎你的加入！
 
@@ -14,7 +14,7 @@ Flutter Candies (糖果群) 成立于 2019 年 2 月 14 日，聚集了一群热
 
 Flutter Candies (糖果社区), established on February 14, 2019, is a distinguished community comprising developers with a shared passion for Flutter. Our unwavering commitment is to incessantly create, maintain, and contribute to a suite of high-quality Flutter plugins and libraries (Flutter / Dart Packages). Our aim is to enhance the accessibility of Flutter, thereby facilitating developers in the expedited and efficient creation of superior Flutter applications.
 
-As of today, we have successfully open-sourced more than [50 practical packages](https://pub.dev/publishers/fluttercandies.com/packages) on pub.dev. However, our contributions extend significantly beyond this. We have also developed a comprehensive range of invaluable tools, APIs, and real-world projects. All of these initiatives are designed to provide robust support to Flutter developers at various stages of their careers, promoting rapid professional advancement.
+As of today, we have successfully open-sourced [<!-- md:PubDashboard-total start -->0<!-- md:PubDashboard-total end --> practical packages](https://pub.dev/publishers/fluttercandies.com/packages) on pub.dev. However, our contributions extend significantly beyond this. We have also developed a comprehensive range of invaluable tools, APIs, and real-world projects. All of these initiatives are designed to provide robust support to Flutter developers at various stages of their careers, promoting rapid professional advancement.
 
 Our vision is to "Empower every developer by building a healthy, powerful, and secure Flutter ecosystem, TOGETHER", we warmly welcome everyone to contribute the practical Flutter packages (little candies). If you share our objectives and vision, join us!
 

--- a/README.template.md
+++ b/README.template.md
@@ -6,7 +6,7 @@
 
 Flutter Candies (糖果群) 成立于 2019 年 2 月 14 日，聚集了一群热爱 Flutter 的开发者们，糖果群致力于通过持续创建、维护和贡献高质量的 Flutter 插件和库 (Flutter / Dart Packages)，让 Flutter 更易用，助力开发者们更快、更高效地构建优秀的 Flutter 应用。
 
-我们已经在 pub.dev 上开源了 [<!-- md:PubDashboard-total start -->0<!-- md:PubDashboard-total end --> 个](https://pub-web.flutter-io.cn/publishers/fluttercandies.com/packages) 实用的 packages，不仅如此，我们还构建了很多实用工具、API、实战项目以及优质的技术文章，帮助 Flutter 开发者们在职业生涯的不同阶段快速成长。
+我们已经在 pub.dev 上开源了 [<!-- md:PubDashboard-total start -->0<!-- md:PubDashboard-total end --> 个](https://github.com/fluttercandies/packages) 实用的 packages，不仅如此，我们还构建了很多实用工具、API、实战项目以及优质的技术文章，帮助 Flutter 开发者们在职业生涯的不同阶段快速成长。
 
 我们希望号召和帮助更多开发者们为 Flutter 开发者更多实用的插件库 (小糖果)，如果你有同样的目标和理想，糖果群欢迎你的加入！
 
@@ -14,7 +14,7 @@ Flutter Candies (糖果群) 成立于 2019 年 2 月 14 日，聚集了一群热
 
 Flutter Candies (糖果社区), established on February 14, 2019, is a distinguished community comprising developers with a shared passion for Flutter. Our unwavering commitment is to incessantly create, maintain, and contribute to a suite of high-quality Flutter plugins and libraries (Flutter / Dart Packages). Our aim is to enhance the accessibility of Flutter, thereby facilitating developers in the expedited and efficient creation of superior Flutter applications.
 
-As of today, we have successfully open-sourced [<!-- md:PubDashboard-total start -->0<!-- md:PubDashboard-total end --> practical packages](https://pub.dev/publishers/fluttercandies.com/packages) on pub.dev. However, our contributions extend significantly beyond this. We have also developed a comprehensive range of invaluable tools, APIs, and real-world projects. All of these initiatives are designed to provide robust support to Flutter developers at various stages of their careers, promoting rapid professional advancement.
+As of today, we have successfully open-sourced [<!-- md:PubDashboard-total start -->0<!-- md:PubDashboard-total end --> practical packages](https://github.com/fluttercandies/packages) on pub.dev. However, our contributions extend significantly beyond this. We have also developed a comprehensive range of invaluable tools, APIs, and real-world projects. All of these initiatives are designed to provide robust support to Flutter developers at various stages of their careers, promoting rapid professional advancement.
 
 Our vision is to "Empower every developer by building a healthy, powerful, and secure Flutter ecosystem, TOGETHER", we warmly welcome everyone to contribute the practical Flutter packages (little candies). If you share our objectives and vision, join us!
 


### PR DESCRIPTION
将简介中的 package 总数更新为了动态的方式。
Package 总数通过以下关键字进行更新。
```
<!-- md:PubDashboard-total start --><!-- md:PubDashboard-total end -->
```

### 讨论
由于部分 package 未发布在 fluttercandies.com 上，所以 pub.dev 的总数与动态更新的总数有差别。
并且当前链接的是 https://pub.dev/publishers/fluttercandies.com/packages 的地址，
是否需要修改为 https://github.com/fluttercandies/packages 的仓库地址，
以展示最完整的 package 列表。

### 注意

当前内容合并后，请麻烦执行一次 [update-fluttercandies-profile-readme.yml](https://github.com/fluttercandies/.github-workflow/blob/main/.github/workflows/update-fluttercandies-profile-readme.yml)